### PR TITLE
Rewrote pulse detection logic

### DIFF
--- a/src/main.ino
+++ b/src/main.ino
@@ -10,8 +10,8 @@
 #include "rf_testing.h"
 #include "wiring_private.h"
 
-#define debug
-#define serial_debug  Serial
+// #define debug
+// #define serial_debug  Serial
 
 // Initialize timer for periodic callback
 // TimerMillis periodic;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -45,9 +45,9 @@ void settings_init(void){
     settings_packet.data.system_charge_min=0;
     settings_packet.data.system_charge_max=255;
     settings_packet.data.system_input_charge_min=10000;
-    settings_packet.data.pulse_threshold=0;
-    settings_packet.data.pulse_on_timeout=0;
-    settings_packet.data.pulse_min_interval=0;
+    settings_packet.data.pulse_threshold=5;
+    settings_packet.data.pulse_on_timeout=120;
+    settings_packet.data.pulse_min_interval=300;
 
     //check if valid settings present in eeprom 
     uint8_t eeprom_settings_address = EEPROM_DATA_START_SETTINGS;

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -65,9 +65,6 @@ void pulse_callback(){
     }
   }
   else{
-    // turn on output
-    pulse_output_on_callback();
-
     while(digitalRead(PULSE_IN) == 1);
     uint32_t end_of_pulse = millis();
     
@@ -98,6 +95,11 @@ void pulse_callback(){
         // do output
         trigger_output = true;
       }
+
+      // When we actually want to trigger the output but the timer is ot running, then skip the trigger.
+      if(trigger_output && timer_pulse_off.active()) {
+        trigger_output = false;
+      }
       
       #ifdef serial_debug
         serial_debug.print("trigger: ");
@@ -119,8 +121,9 @@ void pulse_callback(){
         pulse_counter = 0;
         // send LoRa message
         status_send_flag = HIGH;
-        // schedule a delayed pulse off
-        //timer_pulse_off.stop();
+        // turn on output to power the SDCard
+        pulse_output_on_callback();
+        // schedule a delayed pulse off to power doen the SDCard
         timer_pulse_off.start(pulse_output_off_callback, settings_packet.data.pulse_on_timeout * 1000);
       }
     }

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -2,7 +2,7 @@
 
 uint8_t resetCause = 0xff;
 
-// #define debug
+#define debug
 #define serial_debug  Serial
 
 boolean status_send_flag = false;
@@ -48,9 +48,9 @@ pulse callback does the following
 - if a pulse occurs during this, count up and do nothing
 */
 void pulse_callback(){
-  #ifdef debug
-    serial_debug.println("PULSE DETECTED");
-  #endif
+  // #ifdef debug
+  //   serial_debug.println("PULSE DETECTED");
+  // #endif
 
   pulse_state = digitalRead(PULSE_IN);
   uint32_t start_of_pulse = millis();
@@ -70,10 +70,10 @@ void pulse_callback(){
     
     status_packet.data.duration_of_pulse = (end_of_pulse - start_of_pulse);
     
-    #ifdef debug
-      Serial.print("Duration of pulse is: ");
-      Serial.println(status_packet.data.duration_of_pulse);
-    #endif
+    // #ifdef debug
+    //   Serial.print("Duration of pulse is: ");
+    //   Serial.println(status_packet.data.duration_of_pulse);
+    // #endif
 
     // Only set send flag, if duration of pulse is longer 1900 ms, this will
     // filter out all pulses that were not result of detected PIR activity
@@ -100,22 +100,6 @@ void pulse_callback(){
       if(trigger_output && timer_pulse_off.active()) {
         trigger_output = false;
       }
-      
-      #ifdef serial_debug
-        serial_debug.print("trigger: ");
-        serial_debug.println(trigger_output);
-
-        serial_debug.print("interval: ");
-        serial_debug.print(pulse_interval / 1000);
-        serial_debug.print(" - ");
-        serial_debug.println(settings_packet.data.pulse_min_interval);
-        
-        serial_debug.print("counter: ");
-        serial_debug.print(pulse_counter);
-        serial_debug.print(" - ");
-        serial_debug.println(settings_packet.data.pulse_threshold);
-      #endif
-
       if(trigger_output) {
         pulse_last_time = millis();
         pulse_counter = 0;
@@ -138,6 +122,8 @@ void status_scheduler(void){
 
 #ifdef debug
 serial_debug.print("status_scheduler -( ");
+serial_debug.print("p int: ");
+serial_debug.print(settings_packet.data.pulse_min_interval);
 serial_debug.print("p thr: ");
 serial_debug.print(settings_packet.data.pulse_threshold);
 serial_debug.print(" p to: ");

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -3,7 +3,7 @@
 uint8_t resetCause = 0xff;
 
 // #define debug
-// #define serial_debug  Serial
+#define serial_debug  Serial
 
 boolean status_send_flag = false;
 unsigned long event_status_last = 0;
@@ -86,7 +86,7 @@ void pulse_callback(){
       boolean trigger_output = false;
 
       // if number of pulses threshold has been reached, trigger output
-      if(pulse_counter > settings_packet.data.pulse_threshold){
+      if(pulse_counter >= settings_packet.data.pulse_threshold){
         // do output
         trigger_output = true;
       }
@@ -94,20 +94,24 @@ void pulse_callback(){
       // if enough has passed since last pulse
       uint32_t pulse_interval = millis() - pulse_last_time;
       
-      if(pulse_interval > (settings_packet.data.pulse_min_interval * 1000)){
+      if(pulse_interval >= (settings_packet.data.pulse_min_interval * 1000)){
         // do output
         trigger_output = true;
       }
       
       #ifdef serial_debug
-        serial_debug.print("trigger_output: ");
+        serial_debug.print("trigger: ");
         serial_debug.println(trigger_output);
 
-        serial_debug.print("pulse_interval: ");
-        serial_debug.println(pulse_interval / 1000);
+        serial_debug.print("interval: ");
+        serial_debug.print(pulse_interval / 1000);
+        serial_debug.print(" - ");
+        serial_debug.println(settings_packet.data.pulse_min_interval);
         
-        serial_debug.print("pulse_counter: ");
-        serial_debug.println(pulse_counter);
+        serial_debug.print("counter: ");
+        serial_debug.print(pulse_counter);
+        serial_debug.print(" - ");
+        serial_debug.println(settings_packet.data.pulse_threshold);
       #endif
 
       if(trigger_output) {


### PR DESCRIPTION
I change the pulse detection logic so that:

- Only detect pulses if duration_of_pulse > 1900, in the previous code pulses were detected too often
- Added debug
- Always reset both pulse_last_time and pulse_counter when an output is triggered to create better "or" logic and prevent premature triggers